### PR TITLE
[middleware] Rack::BlastWave::RequestId middleware

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,4 +12,4 @@ AllCops:
     - spec/**/*.rb
     - Gemfile
     - Rakefile
-    - blastwave.gemspec
+    - blast_wave.gemspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@ sudo: false
 language: ruby
 before_install: gem install bundler
 cache: bundler
-rvm:
-- 2.3.7
-- 2.4.4
-- 2.5.1
-- ruby-head
-- jruby-head
+matrix:
+  fast_finish: true
+  include:
+    - rvm: 2.3.7
+    - rvm: 2.4.4
+    - rvm: 2.5.1
+    - rvm: ruby-head
+    - rvm: jruby-head
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
 script:
 - bundle exec rspec
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+### Added
+- `Rack::BlastWave::RequestId` - rack middleware that provides an unique id attribute
+  to the each rack request object and rack `#env` scope;

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Blastwave &middot; [![Build Status](https://travis-ci.org/0exp/blastwave.svg?branch=master)](https://travis-ci.org/0exp/blastwave)
+# BlastWave
 
 In active development...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# BlastWave
+# BlastWave &middot; [![Gem Version](https://badge.fury.io/rb/blast_wave.svg)](https://badge.fury.io/rb/blast_wave) [![Build Status](https://travis-ci.org/0exp/blast_wave.svg?branch=master)](https://travis-ci.org/0exp/blast_wave) [![Coverage Status](https://coveralls.io/repos/github/0exp/blast_wave/badge.svg?branch=master)](https://coveralls.io/github/0exp/blast_wave?branch=master)
 
 In active development...

--- a/bin/console
+++ b/bin/console
@@ -2,10 +2,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'blastwave'
-
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
+require 'blast_wave'
 
 require 'pry'
 Pry.start

--- a/blast_wave.gemspec
+++ b/blast_wave.gemspec
@@ -2,16 +2,16 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'blastwave/version'
+require 'blast_wave/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'blastwave'
-  spec.version       = Blastwave::VERSION
+  spec.name          = 'blast_wave'
+  spec.version       = Rack::BlastWave::VERSION
   spec.authors       = ['Rustam Ibragimov']
   spec.email         = ['iamdaiver@icloud.com']
   spec.summary       = 'Soon'
   spec.description   = 'Soon'
-  spec.homepage      = 'https://github.com/0exp/blastwave'
+  spec.homepage      = 'https://github.com/0exp/blast_wave'
   spec.license       = 'MIT'
 
   spec.bindir        = 'bin'
@@ -22,11 +22,14 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|features)/}) }
   end
 
-  spec.add_development_dependency 'coveralls',        '~> 0.8.21'
-  spec.add_development_dependency 'simplecov',        '~> 0.14.1'
-  spec.add_development_dependency 'simplecov-json',   '~> 0.2'
-  spec.add_development_dependency 'armitage-rubocop', '~> 0.5.0'
-  spec.add_development_dependency 'rspec',            '~> 3.7.0'
+  spec.add_dependency 'rack'
+  spec.add_dependency 'qonfig'
+
+  spec.add_development_dependency 'coveralls',        '~> 0.8'
+  spec.add_development_dependency 'simplecov',        '~> 0.16'
+  spec.add_development_dependency 'armitage-rubocop', '~> 0.5'
+  spec.add_development_dependency 'rspec',            '~> 3.8'
+  spec.add_development_dependency 'rack-test',        '~> 1.1'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/blast_wave.rb
+++ b/lib/blast_wave.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rack'
+require 'rack/test'
+require 'securerandom'
+require 'qonfig'
+
+module Rack
+  # @api public
+  # @since 0.0.0
+  module BlastWave
+    require_relative 'blast_wave/version'
+    require_relative 'blast_wave/middleware'
+    require_relative 'blast_wave/request_id'
+    require_relative 'blast_wave/request_id/extensions/request_interface'
+    require_relative 'blast_wave/request_id/initializer'
+  end
+end

--- a/lib/blast_wave/middleware.rb
+++ b/lib/blast_wave/middleware.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Rack
+  # @api public
+  # @since 0.1.0
+  class BlastWave::Middleware
+    # @return [Object]
+    #
+    # @api public
+    # @since 0.1.0
+    attr_reader :app
+
+    # @param app [Object]
+    # @return [void]
+    #
+    # @api public
+    # @since 0.1.0
+    def initialize(app)
+      @app = app
+    end
+
+    # @param env [Hash]
+    # @return [void]
+    #
+    # @api public
+    # @since 0.1.0
+    def call(env)
+      app.call(env)
+    end
+  end
+end

--- a/lib/blast_wave/request_id.rb
+++ b/lib/blast_wave/request_id.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Rack
+  # @api public
+  # @since 0.1.0
+  class BlastWave::RequestId < BlastWave::Middleware
+    # @since 0.1.0
+    include Qonfig::Configurable
+
+    # @return [String]
+    #
+    # @api public
+    # @since 0.1.0
+    REQUEST_ID_ENV_KEY = 'rack.blastwave.request_id'
+
+    # @since 0.1.0
+    configuration { setting :id_randomizer, -> { SecureRandom.hex } }
+
+    # @param app [Object]
+    # @return [void]
+    #
+    # @api private
+    # @since 0.1.0
+    def initialize(app)
+      super
+      Initializer.call(app)
+    end
+
+    # @param env [Hash]
+    # @return [Object]
+    #
+    # @see Rack::BlastWave::Middleware
+    #
+    # @api private
+    # @since 0.1.0
+    def call(env)
+      append_request_id!(env)
+      super
+    end
+
+    private
+
+    # @return [String]
+    #
+    # @see generate_request_id
+    #
+    # @api private
+    # @since 0.1.0
+    def append_request_id!(env)
+      env[REQUEST_ID_ENV_KEY] = generate_request_id
+    end
+
+    # @return [String]
+    #
+    # @api private
+    # @since 0.1.0
+    def generate_request_id
+      self.class.config.settings.id_randomizer.call
+    end
+  end
+end

--- a/lib/blast_wave/request_id/extensions/request_interface.rb
+++ b/lib/blast_wave/request_id/extensions/request_interface.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Rack
+  class BlastWave::RequestId
+    module Extentions
+      # @api private
+      # @since 0.1.0
+      module RequestInterface
+        # @return [String]
+        #
+        # @api public
+        # @since 0.1.0
+        def request_id
+          env[BlastWave::RequestId::REQUEST_ID_ENV_KEY]
+        end
+      end
+    end
+  end
+end

--- a/lib/blast_wave/request_id/initializer.rb
+++ b/lib/blast_wave/request_id/initializer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Rack
+  class BlastWave::RequestId
+    # @api private
+    # @since 0.1.0
+    module Initializer
+      # @return [Mutex]
+      #
+      # @api private
+      # @since 0.1.0
+      INITIALIZATION_LOCK = Mutex.new
+
+      class << self
+        # @param app [Object]
+        # @return [void]
+        #
+        # @see extend_request_interface!
+        #
+        # @api private
+        # @since 0.1.0
+        def call(app)
+          extend_request_interface!
+        end
+
+        private
+
+        # @return [void]
+        #
+        # @see Rack::BlastWave::RequestId::Extensions::RequestInterface
+        #
+        # @api private
+        # @since 0.1.0
+        def extend_request_interface!
+          INITIALIZATION_LOCK.synchronize do
+            unless Rack::Request.include?(BlastWave::RequestId::Extentions::RequestInterface)
+              Rack::Request.prepend(BlastWave::RequestId::Extentions::RequestInterface)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/blast_wave/version.rb
+++ b/lib/blast_wave/version.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Rack
+  module BlastWave
+    # @return [String]
+    #
+    # @api public
+    # @since 0.0.0
+    VERSION = '0.1.0'
+  end
+end

--- a/lib/blast_wave/version.rb
+++ b/lib/blast_wave/version.rb
@@ -6,6 +6,6 @@ module Rack
     #
     # @api public
     # @since 0.0.0
-    VERSION = '0.1.0'
+    VERSION = '0.0.0'
   end
 end

--- a/lib/blastwave.rb
+++ b/lib/blastwave.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'blastwave/version'
-
-module Blastwave
-  # Your code goes here...
-end

--- a/lib/blastwave/version.rb
+++ b/lib/blastwave/version.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Blastwave
-  VERSION = '0.0.0'
-end

--- a/spec/features/request_id_spec.rb
+++ b/spec/features/request_id_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Rack::BlastWave::RequestId Middleware' do
+  let(:app) { build_fake_rack_app(Rack::BlastWave::RequestId) }
+
+  describe 'request interface' do
+    specify 'request id' do
+      make_request(:get, '/')
+
+      expect(last_request.env.keys).to include('rack.blastwave.request_id')
+      expect(last_request).to respond_to(:request_id)
+      expect(last_request.env['rack.blastwave.request_id']).to eq(last_request.request_id)
+    end
+  end
+
+  describe 'request id randomization' do
+    before do
+      # NOTE: inject fake request id randomizer
+      Rack::BlastWave::RequestId.configure do |conf|
+        fake_id_values = %w[1 2 3 4 5 6 7 8].cycle
+        conf.id_randomizer = -> { fake_id_values.next }
+      end
+    end
+
+    specify 'each request gets his own request_id' do
+      request_results = make_request_series(3, :get, '/')
+
+      # NOTE: 3 unique request ids
+      expect(request_results.map(&:request).map(&:request_id).uniq.count).to eq(3)
+
+      expect(request_results[0].request.env['rack.blastwave.request_id']).to eq('1')
+      expect(request_results[1].request.env['rack.blastwave.request_id']).to eq('2')
+      expect(request_results[2].request.env['rack.blastwave.request_id']).to eq('3')
+    end
+  end
+end

--- a/spec/features/request_id_spec.rb
+++ b/spec/features/request_id_spec.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Rack::BlastWave::RequestId Middleware' do
+  before do
+    # NOTE: inject fake request id randomizer
+    Rack::BlastWave::RequestId.configure do |conf|
+      fake_id_values = %w[1 2 3 4 5 6 7 8].cycle
+      conf.id_randomizer = -> { fake_id_values.next }
+    end
+  end
+
   let(:app) { build_fake_rack_app(Rack::BlastWave::RequestId) }
 
   describe 'request interface' do
@@ -14,14 +22,6 @@ RSpec.describe 'Rack::BlastWave::RequestId Middleware' do
   end
 
   describe 'request id randomization' do
-    before do
-      # NOTE: inject fake request id randomizer
-      Rack::BlastWave::RequestId.configure do |conf|
-        fake_id_values = %w[1 2 3 4 5 6 7 8].cycle
-        conf.id_randomizer = -> { fake_id_values.next }
-      end
-    end
-
     specify 'each request gets his own request_id' do
       request_results = make_request_series(3, :get, '/')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,25 +1,29 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-require 'simplecov-json'
 require 'coveralls'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::JSONFormatter,
   Coveralls::SimpleCov::Formatter
 ])
 
 SimpleCov.start { add_filter 'spec' }
 
 require 'bundler/setup'
-require 'blastwave'
+require 'blast_wave'
 require 'pry'
 
+require_relative 'support/fake_app'
+require_relative 'support/request_helpers'
+
 RSpec.configure do |config|
-  config.disable_monkey_patching!
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.expect_with(:rspec) { |c| c.syntax = :expect }
   config.order = :random
   Kernel.srand config.seed
+
+  config.include Rack::Test::Methods
+  config.include SpecSupport::FakeApp
+  config.include SpecSupport::RequestHelpers
 end

--- a/spec/support/fake_app.rb
+++ b/spec/support/fake_app.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SpecSupport
+  module FakeApp
+    class MinimalRackApp
+      def call(env)
+        Rack::Response.new(env).finish
+      end
+    end
+
+    def build_fake_rack_app(*middlewares)
+      Rack::Builder.new do
+        middlewares.map(&method(:use))
+        run MinimalRackApp.new
+      end
+    end
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module SpecSupport
+  module RequestHelpers
+    class RequestSeriesResult
+      attr_reader :current_time
+      attr_reader :request
+      attr_reader :response
+
+      def initialize(current_time, request, response)
+        @current_time = current_time
+        @request      = request
+        @response     = response
+      end
+    end
+
+    def make_request(method, path, options = {})
+      send(method, path, options)
+    end
+
+    def make_request_series(count, method, path, options = {})
+      [].tap do |request_results|
+        count.times do |current_time|
+          make_request(method, path, options)
+
+          request_results << RequestSeriesResult.new(
+            current_time,
+            last_request,
+            last_response
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- gives an unique request identificator to the each request

```ruby
use Rack::BlastWave::RequestId

request.env['rack.blastwave.request_id'] # => "80f31ba599bd9b9449ea6f2061f40666"
request.request_id # => "80f31ba599bd9b9449ea6f2061f40666"
```

- you can setup a custom id randomizer (by providing a `#call`-able object):

```ruby
Rack::BlastWave::RequestId.configure do |conf|
  random_values = %w[hello world].cycle
  conf.id_randomizer = -> { random_values.next }
end

# first request...
request.request_id # => "hello"
# second request...
request.request_id # => "world"
# third request...
request.request_id # => "hello"
# and etc...
```