### PR TITLE
[readme] Fix 'important' declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BlastWave &middot; [![Gem Version](https://badge.fury.io/rb/blast_wave.svg)](https://badge.fury.io/rb/blast_wave) [![Build Status](https://travis-ci.org/0exp/blast_wave.svg?branch=master)](https://travis-ci.org/0exp/blast_wave) [![Coverage Status](https://coveralls.io/repos/github/0exp/blast_wave/badge.svg?branch=master)](https://coveralls.io/github/0exp/blast_wave?branch=master)
 
-**IMPORTANT!** In active development!
+**!IMPORTANT** In active development!
 
 A set of useful **rack** middlewares.
 


### PR DESCRIPTION
You seem to have accidentally misspelled `!important`.